### PR TITLE
Clarification git flow dans la documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,17 @@ Ajouter un nouveau format = créer la classe + l'importer dans le `__init__.py` 
 - Context managers pour les operations temporaires
 - ABC (Abstract Base Class) pour les interfaces
 
-### Git
-- Git Flow : branches `feature/*`, `release/*`, `hotfix/*`
-- Branche par défaut : `develop` (attention : master existe aussi)
+### Git Flow (IMPORTANT)
+- Branche principale de travail : **develop**
+- `master` = releases uniquement (tags), ne jamais PR directement vers master
+- Workflow obligatoire pour chaque feature/fix :
+  1. `git pull origin develop` (toujours partir de develop a jour)
+  2. `git checkout -b feature/<nom>` (creer une branche feature)
+  3. Travailler, commiter sur la branche feature
+  4. `git push -u origin feature/<nom>`
+  5. Creer la PR **vers develop** (jamais vers master)
+  6. Apres merge, supprimer la branche feature
+- Releases : quand develop est stable, merge develop → master et taguer
 - **Lefthook** : pre-commit lance `mamba spec/` automatiquement
 - **CI** : GitHub Actions sur push/PR (Python 3.10/3.11/3.12)
 - Tests verts obligatoires avant PR

--- a/docs/pr-conventions.md
+++ b/docs/pr-conventions.md
@@ -1,5 +1,45 @@
 # Conventions pour les Pull Requests
 
+## Git Flow
+
+### Workflow obligatoire
+
+Toutes les PR doivent cibler **develop**. Jamais master directement.
+
+```bash
+# 1. Partir de develop a jour
+git checkout develop
+git pull origin develop
+
+# 2. Creer une branche feature
+git checkout -b feature/<nom-descriptif>
+
+# 3. Travailler, commiter
+# ... commits ...
+
+# 4. Pousser la branche
+git push -u origin feature/<nom-descriptif>
+
+# 5. Creer la PR vers develop
+gh pr create --base develop --title "..."
+
+# 6. Apres merge, nettoyer
+git checkout develop
+git pull origin develop
+git branch -d feature/<nom-descriptif>
+```
+
+### Releases
+
+Les releases se font en mergeant develop → master et en taguant :
+
+```bash
+git checkout master
+git merge develop
+git tag v0.x.x
+git push origin master --tags
+```
+
 ## Structure du message
 
 Chaque PR doit contenir deux sections, une en francais et une en anglais,
@@ -34,7 +74,8 @@ Description in english...
 - [ ] Tests mamba au vert (`mamba spec/ --enable-coverage --format=documentation`)
 - [ ] Pas de secrets ou fichiers temporaires dans le diff
 - [ ] Message de commit propre (pas de reference IA)
-- [ ] Branche a jour avec develop
+- [ ] Branche feature creee depuis develop a jour
+- [ ] PR cible develop (pas master)
 
 ## Exemple complet
 


### PR DESCRIPTION
## :fr: Resume

- Mise a jour de CLAUDE.md et docs/pr-conventions.md pour clarifier le git flow
- PR toujours vers develop, master reserve aux releases taggees
- Ajout du workflow detaille (pull develop → feature branch → PR → merge)
- Ajout de la section releases (merge develop → master + tag)

## :gb: Summary

- Updated CLAUDE.md and docs/pr-conventions.md to clarify git flow
- PRs always target develop, master is reserved for tagged releases
- Added detailed workflow (pull develop → feature branch → PR → merge)
- Added releases section (merge develop → master + tag)