### PR TITLE
reecriture README en anglais + fiches doc par node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,105 @@
 # Pixel Palette Art
-Comfyui custom node: Set of tools for pixel art palette.
 
-# Nodes
+A set of ComfyUI custom nodes for pixel art color and palette manipulation.
 
-## Color Preview
+Create colors, mix them in RGB or HSV, build gradients, sort and edit palettes, then export to GIMP, hex, or any format you need.
 
-Cree une image de previsualisation d'une couleur avec son code hex (ou rgb, hsl, css) en overlay.
-Options : taille du texte, position, couleur auto (noir/blanc selon luminosite).
+![Full pipeline example](docs/screenshots/09_comp_full_pipeline_result.png)
 
-![color preview workflow](docs/screenshots/01_color_preview_workflow.png)
+## Installation
 
-![color preview result](docs/screenshots/01_color_preview_result.png)
+Clone this repository into your ComfyUI `custom_nodes` directory:
 
-## Gimp GPL Loader
+```bash
+cd ComfyUI/custom_nodes
+git clone https://github.com/ranska/pixel_palette_art.git
+```
 
-Charge un fichier palette `.gpl` (format GIMP). Les fichiers doivent etre dans le dossier `input`.
+Restart ComfyUI. The nodes will appear under the `pixel_art` category.
 
-Beaucoup de palettes `.gpl` sont disponibles sur [lospec](https://lospec.com/).
+## Nodes
 
-__if you know how to upload a file please PR or open an issue__
+### Colors (`pixel_art/colors`)
 
-![palette node](docs/gimp_gpl_loader.png)
+| Node | Description | Doc |
+|------|-------------|-----|
+| Create Color From RGB | Create a color from R, G, B values | [doc](docs/nodes/create_color_from_rgb.md) |
+| Mix Colors | Blend two colors in RGB or HSV | [doc](docs/nodes/mix_colors.md) |
 
-## Color Creation
+### Palette (`pixel_art/palette`)
 
-Cree une couleur RGB avec nom optionnel, et l'exporte en texte ou image.
+| Node | Description | Doc |
+|------|-------------|-----|
+| Create Gradient Palette | Generate a gradient between two colors | [doc](docs/nodes/create_gradient_palette.md) |
+| Sort Palette | Sort colors by hue or brightness | [doc](docs/nodes/sort_palette.md) |
+| Gradient Between Indices | Interpolate between two palette positions | [doc](docs/nodes/gradient_between.md) |
+| Replace Color At Index | Replace a single color in a palette | [doc](docs/nodes/replace_color_at.md) |
+| Copy Subset | Extract a range of colors from a palette | [doc](docs/nodes/copy_subset.md) |
+| Append Palette | Concatenate two palettes | [doc](docs/nodes/append_palette.md) |
+| Insert Palette At Index | Insert a palette into another at a given position | [doc](docs/nodes/insert_palette_at.md) |
+| Mix Palettes | Blend two palettes color by color | [doc](docs/nodes/mix_palettes.md) |
 
-![color node](docs/create_color.png)
+### Output (`pixel_art/output`)
 
-## Color Mixer
+| Node | Description | Doc |
+|------|-------------|-----|
+| Color Preview | Render a color as an image with text overlay | [doc](docs/nodes/color_preview.md) |
+| Color to Formatted String | Convert a color to hex, rgb, hsl, css, etc. | [doc](docs/nodes/color_formatter.md) |
+| Palette View | Render a palette as a grid or strip image | [doc](docs/nodes/palette_view.md) |
+| Palette Formatter | Export a palette as formatted text | [doc](docs/nodes/palette_formatter.md) |
 
-Le concept central de ce pack de nodes.
+### IO (`pixel_art/io`)
 
-Mixe 2 couleurs pour en obtenir une 3e, avec interpolation RGB ou HSV.
+| Node | Description | Doc |
+|------|-------------|-----|
+| GIMP Palette Loader | Load `.gpl`, `.pal`, or `.aco` palette files | [doc](docs/nodes/gimp_palette_loader.md) |
 
-![color node](docs/mix_colors.png)
+### Image (`image/color`)
 
-# Roadmap
+| Node | Description | Doc |
+|------|-------------|-----|
+| Pixel Palette Extractor | Extract unique colors from an image | [doc](docs/nodes/pixel_palette_extractor.md) |
 
-See issue list.
-The next target are export colors and palettes manipulation.
+## Test Workflows
 
-# Inspiration
+Example workflows are provided in [`workflows/test/`](workflows/test/). Each one demonstrates a specific node or combination of nodes, and can be loaded directly into ComfyUI.
 
+## Contributing
 
-
-https://github.com/45uee/ComfyUI-Color_Transfer
-
-# Contribute
-
-
-## Setup
+### Setup
 
 ```bash
 pip install -r requirements-dev.txt
 lefthook install
 ```
 
-## Tests (BDD avec Mamba)
+### Tests (BDD with Mamba)
 
-Ce projet utilise [mamba](https://github.com/nestorsalceda/mamba) (equivalent Python de RSpec)
-avec [expects](https://expects.readthedocs.io/) pour les assertions.
+This project uses [mamba](https://github.com/nestorsalceda/mamba) (Python equivalent of RSpec) with [expects](https://expects.readthedocs.io/) for assertions.
 
 ```bash
-# Lancer tous les tests
+# Run all tests
 mamba spec/ --format=documentation
 
-# Avec coverage
+# With coverage
 mamba spec/ --enable-coverage --format=documentation
 ```
 
-Les tests sont lances automatiquement avant chaque commit via **lefthook**.
-Si un test echoue, le commit est bloque.
+Tests run automatically before each commit via **lefthook**. CI runs on Python 3.10, 3.11, and 3.12 via GitHub Actions.
 
-Une CI GitHub Actions tourne aussi sur chaque push et PR (Python 3.10/3.11/3.12).
+### Git flow
 
-## Git
-
-Ce repo utilise [git flow](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html).
-La branche par defaut est `develop`.
+The default branch is `develop`. See [docs/pr-conventions.md](docs/pr-conventions.md) for PR guidelines.
 
 ```bash
-# Nouvelle feature
-git flow feature start ma-feature
-
-# Quand c'est pret : push et PR vers develop
-git push -u origin feature/ma-feature
+git checkout develop && git pull
+git checkout -b feature/my-feature
+# work, commit, push
+git push -u origin feature/my-feature
+# open PR towards develop
 ```
 
-Voir `docs/pr-conventions.md` pour les conventions de messages de PR.
+## Inspiration
+
+- [ComfyUI-Color_Transfer](https://github.com/45uee/ComfyUI-Color_Transfer)
+- [Lospec](https://lospec.com/) — pixel art palette database

--- a/docs/nodes/append_palette.md
+++ b/docs/nodes/append_palette.md
@@ -1,0 +1,20 @@
+# Append Palette
+
+Concatenates two palettes into one. All colors from palette B are appended after the colors of palette A.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette_a | PIXEL_PALETTE | — | First palette |
+| palette_b | PIXEL_PALETTE | — | Palette to append |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| combined_palette | PIXEL_PALETTE | The merged palette |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/color_formatter.md
+++ b/docs/nodes/color_formatter.md
@@ -1,0 +1,24 @@
+# Color to Formatted String
+
+Converts a `PIXEL_COLOR` to a formatted text string. Supports many common color formats including hex, RGB tuples, HSL, CSS custom properties, and GIMP palette lines.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| color | PIXEL_COLOR | — | Color to format |
+| format_type | `hex` \| `hex_alpha` \| `rgb` \| `rgba` \| `tuple` \| `tuple_alpha` \| `hsl` \| `css` \| `gimp` | hex | Output format |
+| alpha_value | FLOAT | 1.0 | Alpha as float 0.0–1.0 (for rgba/hex_alpha) |
+| alpha_int | INT | 255 | Alpha as integer 0–255 (for tuple_alpha) |
+| css_var_name | STRING | color | CSS custom property name (for css format) |
+| gimp_index | INT | -1 | Column index in GIMP format (-1 = auto) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| formatted_color | STRING | The formatted color string |
+
+## Category
+
+`pixel_art/output`

--- a/docs/nodes/color_preview.md
+++ b/docs/nodes/color_preview.md
@@ -1,0 +1,33 @@
+# Color Preview
+
+Renders a solid-color image with an optional text overlay showing the color value. The text format (hex, rgb, hsl, css), size, position and color can all be configured.
+
+Useful for previewing individual colors in a ComfyUI workflow.
+
+![Color Preview workflow](../screenshots/01_color_preview_workflow.png)
+
+![Color Preview result](../screenshots/01_color_preview_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| color | PIXEL_COLOR | — | Color to preview |
+| width | INT | 256 | Image width in pixels (64–1024) |
+| height | INT | 256 | Image height in pixels (64–1024) |
+| show_text | BOOLEAN | True | Show color value as text overlay |
+| text_format | `hex` \| `rgb` \| `hsl` \| `css` | hex | Format of the text overlay |
+| text_color | `black` \| `white` \| `auto` | auto | Text color (auto adjusts based on luminance) |
+| text_size | INT | 24 | Font size (12–72) |
+| text_position | `center` \| `bottom` \| `top` | center | Text placement |
+| background_color | STRING | transparent | Background color behind the swatch |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | IMAGE | The preview image |
+
+## Category
+
+`pixel_art/output`

--- a/docs/nodes/copy_subset.md
+++ b/docs/nodes/copy_subset.md
@@ -1,0 +1,21 @@
+# Copy Subset
+
+Extracts a contiguous range of colors from a palette, creating a new smaller palette. Both start and end indices are inclusive.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Source palette |
+| start_index | INT | 0 | First color index to include (0–255) |
+| end_index | INT | 3 | Last color index to include (0–255) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| subset | PIXEL_PALETTE | The extracted sub-palette |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/create_color_from_rgb.md
+++ b/docs/nodes/create_color_from_rgb.md
@@ -1,0 +1,26 @@
+# Create Color From RGB
+
+Creates a `PIXEL_COLOR` from individual red, green and blue channel values, with an optional name.
+
+This is the primary way to define a color for use with other Pixel Palette Art nodes.
+
+![Create Color From RGB](../create_color.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| red | INT | 255 | Red channel (0–255) |
+| green | INT | 0 | Green channel (0–255) |
+| blue | INT | 0 | Blue channel (0–255) |
+| color_name | STRING | *(empty)* | Optional color name |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| color | PIXEL_COLOR | The created color |
+
+## Category
+
+`pixel_art/colors`

--- a/docs/nodes/create_gradient_palette.md
+++ b/docs/nodes/create_gradient_palette.md
@@ -1,0 +1,28 @@
+# Create Gradient Palette
+
+Generates a palette by interpolating between two colors. The number of steps and the color space used for interpolation are configurable.
+
+HSV interpolation produces more vibrant gradients, while RGB interpolation gives more linear transitions.
+
+![Create Gradient Palette workflow](../screenshots/03_create_gradient_palette_workflow.png)
+
+![Create Gradient Palette result](../screenshots/03_create_gradient_palette_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| color_start | PIXEL_COLOR | — | Starting color |
+| color_end | PIXEL_COLOR | — | Ending color |
+| num_colors | INT | 8 | Number of colors in the gradient (2–256) |
+| color_space | `rgb` \| `hsv` | rgb | Color space for interpolation |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| gradient_palette | PIXEL_PALETTE | The generated gradient palette |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/gimp_palette_loader.md
+++ b/docs/nodes/gimp_palette_loader.md
@@ -1,0 +1,23 @@
+# GIMP Palette Loader
+
+Loads a palette file in GIMP `.gpl`, `.pal`, or Adobe `.aco` format. Files must be placed in the ComfyUI `input` directory.
+
+Many `.gpl` palettes are available on [Lospec](https://lospec.com/).
+
+![GIMP Palette Loader](../gimp_gpl_loader.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette_file | FILE | — | Palette file to load (.gpl, .pal, .aco) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| palette | PIXEL_PALETTE | The loaded palette |
+
+## Category
+
+`pixel_art/io`

--- a/docs/nodes/gradient_between.md
+++ b/docs/nodes/gradient_between.md
@@ -1,0 +1,26 @@
+# Gradient Between Indices
+
+Creates a smooth gradient between two colors within an existing palette, identified by their indices. All colors between the two indices are replaced by interpolated values.
+
+![Gradient Between workflow](../screenshots/05_gradient_between_workflow.png)
+
+![Gradient Between result](../screenshots/05_gradient_between_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Source palette containing the start and end colors |
+| index_start | INT | 0 | Index of the starting color (0–255) |
+| index_end | INT | 2 | Index of the ending color (1–255) |
+| color_space | `rgb` \| `hsv` | rgb | Color space for interpolation |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| gradient_palette | PIXEL_PALETTE | Palette with the gradient applied |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/insert_palette_at.md
+++ b/docs/nodes/insert_palette_at.md
@@ -1,0 +1,21 @@
+# Insert Palette At Index
+
+Inserts all colors from a sub-palette into a destination palette at the specified index. Existing colors after the insertion point are shifted forward.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Destination palette |
+| sub_palette | PIXEL_PALETTE | — | Palette to insert |
+| index | INT | 0 | Insertion position (0–255) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| modified_palette | PIXEL_PALETTE | Palette with inserted colors |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/mix_colors.md
+++ b/docs/nodes/mix_colors.md
@@ -1,0 +1,28 @@
+# Mix Colors
+
+Blends two colors together using linear interpolation. Supports mixing in RGB or HSV color space for different blending results.
+
+A ratio of 0.0 returns color A, 1.0 returns color B, and 0.5 returns an even mix.
+
+![Mix Colors workflow](../screenshots/02_mix_colors_workflow.png)
+
+![Mix Colors result](../screenshots/02_mix_colors_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| color_a | PIXEL_COLOR | — | First color |
+| color_b | PIXEL_COLOR | — | Second color |
+| ratio | FLOAT | 0.5 | Blend ratio (0.0 = color A, 1.0 = color B) |
+| color_space | `rgb` \| `hsv` | rgb | Color space for interpolation |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| mixed_color | PIXEL_COLOR | The blended color |
+
+## Category
+
+`pixel_art/colors`

--- a/docs/nodes/mix_palettes.md
+++ b/docs/nodes/mix_palettes.md
@@ -1,0 +1,25 @@
+# Mix Palettes
+
+Blends two palettes together color by color. Each color at position *i* in palette A is mixed with the color at position *i + offset* in palette B.
+
+Supports RGB and HSV interpolation. The offset parameter allows shifting palette B before mixing.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette_a | PIXEL_PALETTE | — | First palette |
+| palette_b | PIXEL_PALETTE | — | Second palette |
+| ratio | FLOAT | 0.5 | Blend ratio (0.0 = palette A, 1.0 = palette B) |
+| color_space | `rgb` \| `hsv` | rgb | Color space for interpolation |
+| offset | INT | 0 | Index offset applied to palette B (0–255) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| mixed_palette | PIXEL_PALETTE | The blended palette |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/palette_formatter.md
+++ b/docs/nodes/palette_formatter.md
@@ -1,0 +1,25 @@
+# Palette Formatter
+
+Exports a palette as a formatted text string. Supports RGB, hex, raw tuple, and GIMP `.gpl` formats. Useful for copying palettes to external tools or saving them as text.
+
+![Palette Formatter workflow](../screenshots/08_palette_formatter_workflow.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Palette to format |
+| format_type | `rgb` \| `hex` \| `raw` \| `gimp` | rgb | Output format |
+| separator | STRING | `\n` | Separator between color entries |
+| include_header | BOOLEAN | True | Include format header (e.g. GIMP Palette header) |
+| include_names | BOOLEAN | True | Include color names in output |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| formatted_text | STRING | The formatted palette text |
+
+## Category
+
+`pixel_art/output`

--- a/docs/nodes/palette_view.md
+++ b/docs/nodes/palette_view.md
@@ -1,0 +1,29 @@
+# Palette View
+
+Renders a palette as an image with configurable layout. Colors can be displayed in a grid, a horizontal strip, or a vertical strip. Optional overlays show color names, hex values, or indices.
+
+![Palette View workflow](../screenshots/07_palette_view_workflow.png)
+
+![Palette View result](../screenshots/07_palette_view_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Palette to visualize |
+| layout | `grid` \| `horizontal` \| `vertical` | grid | Layout mode |
+| cell_size | INT | 32 | Size of each color cell in pixels (8–128) |
+| columns | INT | 8 | Number of columns in grid layout (1–64) |
+| show_names | BOOLEAN | False | Show color names on each cell |
+| show_indices | BOOLEAN | False | Show color indices on each cell |
+| show_hex | BOOLEAN | False | Show hex values on each cell |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| image | IMAGE | The rendered palette image |
+
+## Category
+
+`pixel_art/output`

--- a/docs/nodes/pixel_palette_extractor.md
+++ b/docs/nodes/pixel_palette_extractor.md
@@ -1,0 +1,23 @@
+# Pixel Palette Extractor
+
+Extracts unique colors from an image and renders them as a palette grid. Useful for analyzing the color composition of pixel art or any image.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| image | IMAGE | — | Source image |
+| palette_width | INT | 16 | Number of colors per row (1–32) |
+| color_size | INT | 32 | Size of each color cell in pixels (8–128) |
+| show_indices | BOOLEAN | False | Show color indices on each cell |
+| font_size | INT | 10 | Font size for index labels (6–24) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| palette_image | IMAGE | The rendered palette image |
+
+## Category
+
+`image/color`

--- a/docs/nodes/replace_color_at.md
+++ b/docs/nodes/replace_color_at.md
@@ -1,0 +1,25 @@
+# Replace Color At Index
+
+Replaces a single color in a palette at the specified index.
+
+![Replace Color At workflow](../screenshots/06_replace_color_at_workflow.png)
+
+![Replace Color At result](../screenshots/06_replace_color_at_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Palette to modify |
+| color | PIXEL_COLOR | — | New color to insert |
+| index | INT | 0 | Position to replace (0–255) |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| modified_palette | PIXEL_PALETTE | Palette with the replaced color |
+
+## Category
+
+`pixel_art/palette`

--- a/docs/nodes/sort_palette.md
+++ b/docs/nodes/sort_palette.md
@@ -1,0 +1,24 @@
+# Sort Palette
+
+Sorts the colors of a palette by hue or brightness. Useful for organizing palettes into a visually coherent order.
+
+![Sort Palette workflow](../screenshots/04_sort_palette_workflow.png)
+
+![Sort Palette result](../screenshots/04_sort_palette_result.png)
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| palette | PIXEL_PALETTE | — | Palette to sort |
+| sort_by | `hue` \| `brightness` | hue | Sorting criterion |
+
+## Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| sorted_palette | PIXEL_PALETTE | The sorted palette |
+
+## Category
+
+`pixel_art/palette`


### PR DESCRIPTION
## Summary

- README reecrit entierement en anglais avec sommaire par categorie (Colors, Palette, Output, IO, Image)
- 16 fiches individuelles creees dans `docs/nodes/` avec description, tableaux inputs/outputs, screenshots et categorie ComfyUI
- Liens du README vers chaque fiche verifies

## Test plan

- [ ] Verifier le rendu markdown du README sur GitHub
- [ ] Verifier les liens relatifs vers docs/nodes/*.md
- [ ] Verifier les chemins des screenshots dans les fiches