### PR TITLE
Ajout seuil coverage 90% en CI et badges README

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,6 @@ omit =
     setup.py
     demo_gradient.py
     test_node_import.py
+
+[report]
+fail_under = 90

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Run tests
         run: mamba spec/ --enable-coverage --format=documentation
+
+      - name: Check coverage threshold
+        run: coverage report --fail-under=90

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Pixel Palette Art
 
+![Tests](https://github.com/ranska/pixel_palette_art/actions/workflows/tests.yml/badge.svg?branch=develop)
+![Coverage](https://img.shields.io/badge/coverage->90%25-brightgreen)
+
 A set of ComfyUI custom nodes for pixel art color and palette manipulation.
 
 Create colors, mix them in RGB or HSV, build gradients, sort and edit palettes, then export to GIMP, hex, or any format you need.
@@ -84,6 +87,8 @@ mamba spec/ --format=documentation
 # With coverage
 mamba spec/ --enable-coverage --format=documentation
 ```
+
+Le seuil de coverage minimum est fixé à **90%**. La CI échoue si le coverage passe en dessous.
 
 Tests run automatically before each commit via **lefthook**. CI runs on Python 3.10, 3.11, and 3.12 via GitHub Actions.
 


### PR DESCRIPTION
## Summary

- Ajout d'une étape `Check coverage threshold` dans le workflow CI (`coverage report --fail-under=90`)
- Ajout de `fail_under = 90` dans `.coveragerc` pour cohérence en local
- Badges Tests CI et Coverage (>90%) en tête du README
- Mention du seuil de coverage dans la section tests du README

## Fichiers modifiés

- `.github/workflows/tests.yml`
- `.coveragerc`
- `README.md`

## Test plan

- [x] `mamba spec/ --enable-coverage` passe (193 specs)
- [x] `coverage report --fail-under=90` passe (94% actuellement)
- [x] Vérification visuelle du README (badges + mention seuil)