### PR TITLE
Ajout exporters CSS et Amiga OCS/ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Restart ComfyUI. The nodes will appear under the `pixel_art` category.
 |------|-------------|-----|
 | Pixel Palette Extractor | Extract unique colors from an image | [doc](docs/nodes/pixel_palette_extractor.md) |
 
+## Export Formats
+
+Le node **Palette Formatter** supporte les formats d'export suivants :
+
+| Format | Description | Exemple de sortie |
+|--------|-------------|-------------------|
+| `rgb` | Valeurs RGB texte | `255  0  0  Rouge` |
+| `hex` | Hexadécimal | `#ff0000` |
+| `gimp` | GIMP Palette `.gpl` | Header GIMP + `255  0  0  Rouge` |
+| `css` | Variables CSS custom properties | `--rouge: #ff0000;` |
+| `amiga` | Amiga OCS/ECS 12-bit (txt ou C) | `#F00` ou `0x0F00` |
+| `raw` | Données brutes | Représentation interne |
+
+Le système d'export est extensible via le pattern Registry. Voir `docs/architecture-registries.md`.
+
 ## Test Workflows
 
 Example workflows are provided in [`workflows/test/`](workflows/test/). Each one demonstrates a specific node or combination of nodes, and can be loaded directly into ComfyUI.

--- a/lib/palette/exporters/__init__.py
+++ b/lib/palette/exporters/__init__.py
@@ -5,8 +5,12 @@ from .exporter_registry import ExporterRegistry
 from .gimp_exporter import GimpExporter
 from .hex_exporter import HexExporter
 from .rgb_exporter import RGBExporter
+from .css_exporter import CSSExporter
+from .amiga_exporter import AmigaExporter
 
 # Enregistrer les exporteurs
 ExporterRegistry.register("gimp", GimpExporter)
 ExporterRegistry.register("hex", HexExporter)
 ExporterRegistry.register("rgb", RGBExporter)
+ExporterRegistry.register("css", CSSExporter)
+ExporterRegistry.register("amiga", AmigaExporter)

--- a/lib/palette/exporters/amiga_exporter.py
+++ b/lib/palette/exporters/amiga_exporter.py
@@ -1,0 +1,66 @@
+# lib/palette/exporters/amiga_exporter.py
+
+from typing import List
+from .base_exporter import BaseExporter
+from ...pixel_color import PixelColor
+
+
+class AmigaExporter(BaseExporter):
+    """Exporteur pour le format Amiga OCS/ECS (couleurs 12-bit)."""
+
+    def export(self, colors: List[PixelColor], **kwargs) -> str:
+        """Exporte en couleurs 12-bit pour Amiga 500/600."""
+        output_format = kwargs.get('output_format', 'txt')
+        include_names = kwargs.get('include_names', False)
+        palette_name = kwargs.get('palette_name', 'Palette')
+
+        if output_format == 'c':
+            return self._export_c(colors, include_names, palette_name)
+        return self._export_txt(colors, include_names)
+
+    def _export_txt(self, colors: List[PixelColor], include_names: bool) -> str:
+        """Export au format texte simple (#RGB)."""
+        lines = []
+        for color in colors:
+            r = self.quantize_channel(color.r)
+            g = self.quantize_channel(color.g)
+            b = self.quantize_channel(color.b)
+            line = f"#{r:01X}{g:01X}{b:01X}"
+            if include_names and color.name:
+                line += f"  /* {color.name} */"
+            lines.append(line)
+        return "\n".join(lines)
+
+    def _export_c(self, colors: List[PixelColor], include_names: bool, palette_name: str) -> str:
+        """Export au format C (tableau UWORD pour Amiga)."""
+        lines = []
+        lines.append(f"// Palette: {palette_name}")
+        lines.append(f"// Colors: {len(colors)}")
+        lines.append(f"#define PALETTE_SIZE {len(colors)}")
+        lines.append("")
+        lines.append("UWORD palette[] = {")
+
+        for i, color in enumerate(colors):
+            r = self.quantize_channel(color.r)
+            g = self.quantize_channel(color.g)
+            b = self.quantize_channel(color.b)
+            value = f"0x0{r:01X}{g:01X}{b:01X}"
+            is_last = (i == len(colors) - 1)
+
+            if include_names and color.name:
+                comment = f"  /* {color.name} */"
+            else:
+                comment = ""
+
+            if is_last:
+                lines.append(f"  {value}{comment}")
+            else:
+                lines.append(f"  {value},{comment}")
+
+        lines.append("};")
+        return "\n".join(lines)
+
+    @staticmethod
+    def quantize_channel(value: int) -> int:
+        """Quantifie un canal 8-bit (0-255) en 4-bit (0-15)."""
+        return round(value / 255 * 15)

--- a/lib/palette/exporters/css_exporter.py
+++ b/lib/palette/exporters/css_exporter.py
@@ -1,0 +1,41 @@
+# lib/palette/exporters/css_exporter.py
+
+import re
+from typing import List
+from .base_exporter import BaseExporter
+from ...pixel_color import PixelColor
+
+
+class CSSExporter(BaseExporter):
+    """Exporteur pour le format CSS custom properties."""
+
+    def export(self, colors: List[PixelColor], **kwargs) -> str:
+        """Exporte comme variables CSS custom properties."""
+        include_names = kwargs.get('include_names', True)
+        selector = kwargs.get('selector', ':root')
+
+        lines = [f"{selector} {{"]
+        for i, color in enumerate(colors):
+            if include_names and color.name:
+                var_name = self._sanitize_css_name(color.name)
+            else:
+                var_name = f"color-{i}"
+            lines.append(f"  --{var_name}: {color.hex};")
+        lines.append("}")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _sanitize_css_name(name: str) -> str:
+        """Transforme un nom en identifiant CSS valide."""
+        # Lowercase
+        name = name.lower()
+        # Espaces et underscores → tirets
+        name = name.replace(' ', '-').replace('_', '-')
+        # Suppression des caracteres non alphanumeriques (sauf tirets)
+        name = re.sub(r'[^a-z0-9-]', '', name)
+        # Suppression des tirets multiples
+        name = re.sub(r'-+', '-', name)
+        # Suppression des tirets en debut et fin
+        name = name.strip('-')
+        return name

--- a/nodes/palette_formatter_node.py
+++ b/nodes/palette_formatter_node.py
@@ -14,7 +14,7 @@ class PaletteFormatterNode:
         return {
             "required": {
                 "palette": ("PIXEL_PALETTE",),
-                "format_type": (["rgb", "hex", "raw", "gimp"], {"default": "rgb"}),
+                "format_type": (["rgb", "hex", "raw", "gimp", "css", "amiga"], {"default": "rgb"}),
             },
             "optional": {
                 "separator": ("STRING", {"default": "\n"}),

--- a/spec/palette/exporters/amiga_exporter_spec.py
+++ b/spec/palette/exporters/amiga_exporter_spec.py
@@ -1,0 +1,131 @@
+# spec/palette/exporters/amiga_exporter_spec.py
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+
+from lib.palette.exporters.amiga_exporter import AmigaExporter
+from lib.pixel_color import PixelColor
+from mamba import description, context, it
+from expects import expect, equal, contain, start_with, end_with
+
+
+with description('AmigaExporter') as self:
+
+    with context('quantize_channel'):
+        with it('quantifie 0 en 0'):
+            expect(AmigaExporter.quantize_channel(0)).to(equal(0))
+
+        with it('quantifie 255 en 15'):
+            expect(AmigaExporter.quantize_channel(255)).to(equal(15))
+
+        with it('quantifie 128 en 8'):
+            expect(AmigaExporter.quantize_channel(128)).to(equal(8))
+
+        with it('quantifie 17 en 1'):
+            expect(AmigaExporter.quantize_channel(17)).to(equal(1))
+
+    with context('format txt'):
+        with it('exporte une couleur en #RGB'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0)]
+            result = exporter.export(colors)
+            expect(result).to(equal("#F00"))
+
+        with it('exporte plusieurs couleurs'):
+            exporter = AmigaExporter()
+            colors = [
+                PixelColor(255, 0, 0),
+                PixelColor(0, 255, 0),
+                PixelColor(0, 0, 255),
+            ]
+            result = exporter.export(colors)
+            lines = result.split('\n')
+            expect(len(lines)).to(equal(3))
+            expect(lines[0]).to(equal("#F00"))
+            expect(lines[1]).to(equal("#0F0"))
+            expect(lines[2]).to(equal("#00F"))
+
+        with it('inclut les noms quand demande'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0, "Rouge")]
+            result = exporter.export(colors, include_names=True)
+            expect(result).to(contain("/* Rouge */"))
+
+        with it('exporte blanc en #FFF'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 255, 255)]
+            result = exporter.export(colors)
+            expect(result).to(equal("#FFF"))
+
+        with it('exporte noir en #000'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(0, 0, 0)]
+            result = exporter.export(colors)
+            expect(result).to(equal("#000"))
+
+    with context('format c'):
+        with it('inclut le header avec le nom de palette'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0)]
+            result = exporter.export(colors, output_format='c', palette_name='Test')
+            expect(result).to(contain("// Palette: Test"))
+
+        with it('inclut PALETTE_SIZE'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0), PixelColor(0, 255, 0)]
+            result = exporter.export(colors, output_format='c')
+            expect(result).to(contain("#define PALETTE_SIZE 2"))
+
+        with it('genere un tableau UWORD'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0)]
+            result = exporter.export(colors, output_format='c')
+            expect(result).to(contain("UWORD palette[] = {"))
+
+        with it('exporte les valeurs 12-bit correctement'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0)]
+            result = exporter.export(colors, output_format='c')
+            expect(result).to(contain("0x0F00"))
+
+        with it('termine le tableau avec un point-virgule'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0)]
+            result = exporter.export(colors, output_format='c')
+            expect(result).to(end_with("};"))
+
+        with it('pas de virgule apres le dernier element'):
+            exporter = AmigaExporter()
+            colors = [
+                PixelColor(255, 0, 0, "Rouge"),
+                PixelColor(0, 255, 0, "Vert"),
+            ]
+            result = exporter.export(colors, output_format='c', include_names=True)
+            lines = result.split('\n')
+            # Avant-derniere ligne = dernier element (sans virgule)
+            last_entry = lines[-2]
+            expect(last_entry).to(contain("0x00F0"))
+            expect(last_entry).not_to(contain(","))
+            # L'avant-avant-derniere doit avoir une virgule
+            first_entry = lines[-3]
+            expect(first_entry).to(contain("0x0F00,"))
+
+        with it('inclut les noms en commentaires'):
+            exporter = AmigaExporter()
+            colors = [PixelColor(255, 0, 0, "Rouge")]
+            result = exporter.export(colors, output_format='c', include_names=True)
+            expect(result).to(contain("/* Rouge */"))
+
+    with context('palette vide'):
+        with it('retourne une chaine vide en format txt'):
+            exporter = AmigaExporter()
+            result = exporter.export([])
+            expect(result).to(equal(""))
+
+        with it('genere un tableau vide en format c'):
+            exporter = AmigaExporter()
+            result = exporter.export([], output_format='c')
+            expect(result).to(contain("#define PALETTE_SIZE 0"))
+            expect(result).to(contain("UWORD palette[] = {"))
+            expect(result).to(contain("};"))

--- a/spec/palette/exporters/css_exporter_spec.py
+++ b/spec/palette/exporters/css_exporter_spec.py
@@ -1,0 +1,99 @@
+# spec/palette/exporters/css_exporter_spec.py
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+
+from lib.palette.exporters.css_exporter import CSSExporter
+from lib.pixel_color import PixelColor
+from mamba import description, context, it
+from expects import expect, equal, contain, start_with, end_with
+
+
+with description('CSSExporter') as self:
+
+    with context('export basique'):
+        with it('utilise le selecteur :root par defaut'):
+            exporter = CSSExporter()
+            colors = [PixelColor(255, 0, 0, "Red")]
+            result = exporter.export(colors)
+            expect(result).to(start_with(":root {"))
+
+        with it('ferme le bloc avec une accolade'):
+            exporter = CSSExporter()
+            colors = [PixelColor(255, 0, 0, "Red")]
+            result = exporter.export(colors)
+            expect(result).to(end_with("}"))
+
+        with it('exporte une couleur avec son nom'):
+            exporter = CSSExporter()
+            colors = [PixelColor(255, 0, 0, "Red")]
+            result = exporter.export(colors)
+            expect(result).to(contain("--red: #ff0000;"))
+
+        with it('exporte une couleur sans nom avec un index'):
+            exporter = CSSExporter()
+            colors = [PixelColor(0, 0, 255)]
+            result = exporter.export(colors)
+            expect(result).to(contain("--color-0: #0000ff;"))
+
+        with it('exporte plusieurs couleurs'):
+            exporter = CSSExporter()
+            colors = [
+                PixelColor(255, 0, 0, "Red"),
+                PixelColor(0, 255, 0, "Green"),
+                PixelColor(0, 0, 255, "Blue"),
+            ]
+            result = exporter.export(colors)
+            expect(result).to(contain("--red: #ff0000;"))
+            expect(result).to(contain("--green: #00ff00;"))
+            expect(result).to(contain("--blue: #0000ff;"))
+
+    with context('include_names=False'):
+        with it('utilise des index pour toutes les couleurs'):
+            exporter = CSSExporter()
+            colors = [
+                PixelColor(255, 0, 0, "Red"),
+                PixelColor(0, 255, 0, "Green"),
+            ]
+            result = exporter.export(colors, include_names=False)
+            expect(result).to(contain("--color-0: #ff0000;"))
+            expect(result).to(contain("--color-1: #00ff00;"))
+
+    with context('selecteur personnalise'):
+        with it('utilise le selecteur fourni'):
+            exporter = CSSExporter()
+            colors = [PixelColor(255, 0, 0, "Red")]
+            result = exporter.export(colors, selector=".palette")
+            expect(result).to(start_with(".palette {"))
+
+    with context('sanitisation CSS'):
+        with it('convertit les espaces en tirets'):
+            result = CSSExporter._sanitize_css_name("Dark Red")
+            expect(result).to(equal("dark-red"))
+
+        with it('convertit les underscores en tirets'):
+            result = CSSExporter._sanitize_css_name("dark_red")
+            expect(result).to(equal("dark-red"))
+
+        with it('supprime les caracteres speciaux'):
+            result = CSSExporter._sanitize_css_name("rouge@#$!")
+            expect(result).to(equal("rouge"))
+
+        with it('passe en lowercase'):
+            result = CSSExporter._sanitize_css_name("ROUGE")
+            expect(result).to(equal("rouge"))
+
+        with it('supprime les tirets multiples'):
+            result = CSSExporter._sanitize_css_name("dark - - red")
+            expect(result).to(equal("dark-red"))
+
+        with it('retourne une chaine vide pour un nom sans caracteres valides'):
+            result = CSSExporter._sanitize_css_name("@#$!")
+            expect(result).to(equal(""))
+
+    with context('palette vide'):
+        with it('exporte un bloc vide'):
+            exporter = CSSExporter()
+            result = exporter.export([])
+            expect(result).to(equal(":root {\n}"))


### PR DESCRIPTION
## Summary

- **CSSExporter** : export en custom properties CSS (`:root`, sélecteur custom, sanitisation des noms)
- **AmigaExporter** : export 12-bit Amiga OCS/ECS en format txt (`#RGB`) et C (tableau `UWORD`)
- Enregistrement des deux exporters dans le registry + ajout dans le node PaletteFormatter
- Specs complètes pour les deux exporters (27 specs)
- Section **Export Formats** ajoutée dans le README

## Test plan

- [x] 193 specs vertes (`mamba spec/ --enable-coverage`)
- [x] Coverage >= 90%
- [x] Lefthook pre-commit passé