### PR TITLE
implementation parser ACO, coverage 96%, doc exporters

### DIFF
--- a/docs/nodes/palette_formatter.md
+++ b/docs/nodes/palette_formatter.md
@@ -9,7 +9,7 @@ Exports a palette as a formatted text string. Supports RGB, hex, raw tuple, and 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | palette | PIXEL_PALETTE | — | Palette to format |
-| format_type | `rgb` \| `hex` \| `raw` \| `gimp` | rgb | Output format |
+| format_type | `rgb` \| `hex` \| `raw` \| `gimp` \| `css` \| `amiga` | rgb | Output format |
 | separator | STRING | `\n` | Separator between color entries |
 | include_header | BOOLEAN | True | Include format header (e.g. GIMP Palette header) |
 | include_names | BOOLEAN | True | Include color names in output |
@@ -19,6 +19,17 @@ Exports a palette as a formatted text string. Supports RGB, hex, raw tuple, and 
 | Name | Type | Description |
 |------|------|-------------|
 | formatted_text | STRING | The formatted palette text |
+
+## Formats disponibles
+
+| Format | Description |
+|--------|-------------|
+| `rgb` | Valeurs RGB : `rgb(255, 128, 0)` |
+| `hex` | Hexadécimal : `#FF8000` |
+| `raw` | Tuples bruts : `(255, 128, 0)` |
+| `gimp` | Format GIMP `.gpl` avec header et métadonnées |
+| `css` | Variables CSS : `--color-0: #FF8000;` — prêt à copier dans une feuille de style |
+| `amiga` | Format Amiga OCS/ECS : valeurs RGB sur 4 bits (0-15), compatible avec les palettes rétro Amiga |
 
 ## Category
 

--- a/lib/parsers/adobe_aco_parser.py
+++ b/lib/parsers/adobe_aco_parser.py
@@ -1,19 +1,58 @@
 # lib/parsers/adobe_aco_parser.py
 
+import struct
 from .base_parser import BaseParser
 from ..pixel_color import PixelColor
 
+
 class AdobeAcoParser(BaseParser):
-    """Parser pour les palettes Adobe ACO (binaire)."""
+    """Parser pour les palettes Adobe ACO (binaire).
+
+    Format ACO v1 :
+    - 2 octets : version (0x0001)
+    - 2 octets : nombre de couleurs (big-endian uint16)
+    - Par couleur : 2 octets color space + 4×2 octets canaux (big-endian uint16)
+    Seul le color space 0 (RGB) est supporté, les autres sont ignorés.
+    """
+
+    # Taille d'un bloc couleur : 2 (color space) + 4×2 (canaux) = 10 octets
+    _COLOR_BLOCK_SIZE = 10
+    # Taille minimale : 2 (version) + 2 (count) = 4 octets
+    _HEADER_SIZE = 4
 
     def can_parse(self, content: str) -> bool:
-        """Détecte si c'est une palette Adobe (binaire)"""
+        """Détecte si c'est une palette Adobe ACO v1"""
         if isinstance(content, bytes) and len(content) >= 2:
             return content[0] == 0x00 and content[1] == 0x01
         return False
 
     def parse(self, content: str) -> list:
-        """Parse une palette Adobe ACO (binaire) - implémentation basique"""
-        # Cette méthode nécessiterait une implémentation binaire plus complexe
-        # Pour l'instant, retourne une liste vide
-        return []
+        """Parse une palette Adobe ACO binaire.
+
+        Retourne les couleurs RGB trouvées. Les couleurs non-RGB sont ignorées.
+        En cas de fichier tronqué, retourne les couleurs lues avant la troncature.
+        """
+        if not isinstance(content, bytes) or len(content) < self._HEADER_SIZE:
+            return []
+
+        num_colors = struct.unpack('>H', content[2:4])[0]
+        colors = []
+        offset = self._HEADER_SIZE
+
+        for _ in range(num_colors):
+            # Vérifier qu'on a assez d'octets pour lire un bloc couleur
+            if offset + self._COLOR_BLOCK_SIZE > len(content):
+                break
+
+            color_space = struct.unpack('>H', content[offset:offset + 2])[0]
+            w, x, y, z = struct.unpack('>HHHH', content[offset + 2:offset + 10])
+            offset += self._COLOR_BLOCK_SIZE
+
+            # Seul RGB (color space 0) est supporté
+            if color_space == 0:
+                r = round(w * 255 / 65535)
+                g = round(x * 255 / 65535)
+                b = round(y * 255 / 65535)
+                colors.append(PixelColor(r, g, b))
+
+        return colors

--- a/spec/color/color_spaces/hsv/hsv_mixer_spec.py
+++ b/spec/color/color_spaces/hsv/hsv_mixer_spec.py
@@ -49,5 +49,24 @@ with description('PixelColor') as self:
             expect(color_a.g).to(equal(255))
             expect(color_a.b).to(equal(0))
 
-    with context('with default color space'):
-        print("TODO: test with 2nd color_space like hsl")
+    with context('wrapping de teinte (ecart > 180 degres)'):
+        with it('mix rouge (0) et bleu (240) passe par le chemin court (dh -= 1)'):
+            # Rouge = 0°, Bleu = 240° → écart > 180°, dh positif → dh -= 1
+            color_a = PixelColor(255, 0, 0, "red")
+            color_b = PixelColor(0, 0, 255, "blue")
+
+            with color_a.using_color_space('hsv'):
+                color_a.mix_with(color_b, 0.5)
+            # Le mix doit passer par magenta/rose, pas par vert
+            # On vérifie que le résultat a une composante rouge significative
+            expect(color_a.r).not_to(equal(0))
+
+        with it('mix bleu (240) et rouge (0) passe par le chemin court (dh += 1)'):
+            # Bleu = 240°, Rouge = 0° → écart > 180°, dh négatif → dh += 1
+            color_a = PixelColor(0, 0, 255, "blue")
+            color_b = PixelColor(255, 0, 0, "red")
+
+            with color_a.using_color_space('hsv'):
+                color_a.mix_with(color_b, 0.5)
+            # Même résultat attendu (passage par magenta)
+            expect(color_a.r).not_to(equal(0))

--- a/spec/palette/exporter_context_spec.py
+++ b/spec/palette/exporter_context_spec.py
@@ -1,0 +1,87 @@
+# spec/palette/exporter_context_spec.py
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
+
+from lib.palette.exporter_context import PaletteExporter
+from lib.pixel_palette import PixelPalette
+from lib.pixel_color import PixelColor
+from mamba import description, context, it, before
+from expects import expect, equal, be_a, have_length, raise_error, be_empty
+
+
+with description('PaletteExporter') as self:
+
+    with before.each:
+        self.colors = [
+            PixelColor(255, 0, 0, "Rouge"),
+            PixelColor(0, 255, 0, "Vert"),
+            PixelColor(0, 0, 255, "Bleu"),
+        ]
+        self.palette = PixelPalette(name="Test", colors=self.colors)
+
+    with context('context manager'):
+        with it('retourne self a l entree du context'):
+            ctx = PaletteExporter(self.palette, 'rgb')
+            result = ctx.__enter__()
+            expect(result).to(equal(ctx))
+            ctx.__exit__(None, None, None)
+
+        with it('initialise l exporter dans le context'):
+            with PaletteExporter(self.palette, 'rgb') as ctx:
+                expect(ctx.exporter).not_to(equal(None))
+
+    with context('export'):
+        with it('retourne le contenu formate'):
+            with PaletteExporter(self.palette, 'rgb') as ctx:
+                result = ctx.export(include_names=True)
+                expect(result).to(be_a(str))
+                # Doit contenir les valeurs RGB
+                expect('255' in result).to(equal(True))
+
+        with it('passe les kwargs au exporter'):
+            with PaletteExporter(self.palette, 'rgb') as ctx:
+                result = ctx.export(separator=', ', include_names=False)
+                # Separator virgule au lieu de newline
+                expect(', ' in result).to(equal(True))
+
+    with context('export_list'):
+        with it('retourne une liste de strings'):
+            with PaletteExporter(self.palette, 'rgb') as ctx:
+                result = ctx.export_list()
+                expect(result).to(have_length(3))
+                expect(result[0]).to(be_a(str))
+
+        with it('retourne une liste vide pour une palette vide'):
+            empty_palette = PixelPalette(name="Vide", colors=[])
+            with PaletteExporter(empty_palette, 'rgb') as ctx:
+                result = ctx.export_list()
+                expect(result).to(be_empty)
+
+    with context('export_tuples'):
+        with it('retourne des tuples RGB avec RGBExporter'):
+            with PaletteExporter(self.palette, 'rgb') as ctx:
+                result = ctx.export_tuples()
+                expect(result).to(have_length(3))
+                expect(result[0]).to(equal((255, 0, 0)))
+                expect(result[1]).to(equal((0, 255, 0)))
+                expect(result[2]).to(equal((0, 0, 255)))
+
+        with it('retourne une liste vide avec GimpExporter (pas de export_tuples)'):
+            with PaletteExporter(self.palette, 'gimp') as ctx:
+                result = ctx.export_tuples()
+                expect(result).to(be_empty)
+
+    with context('appels hors context'):
+        with it('export leve RuntimeError'):
+            ctx = PaletteExporter(self.palette, 'rgb')
+            expect(lambda: ctx.export()).to(raise_error(RuntimeError))
+
+        with it('export_list leve RuntimeError'):
+            ctx = PaletteExporter(self.palette, 'rgb')
+            expect(lambda: ctx.export_list()).to(raise_error(RuntimeError))
+
+        with it('export_tuples leve RuntimeError'):
+            ctx = PaletteExporter(self.palette, 'rgb')
+            expect(lambda: ctx.export_tuples()).to(raise_error(RuntimeError))

--- a/spec/palette/exporters/exporter_registry_spec.py
+++ b/spec/palette/exporters/exporter_registry_spec.py
@@ -1,0 +1,55 @@
+# spec/palette/exporters/exporter_registry_spec.py
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+
+from lib.palette.exporters.exporter_registry import ExporterRegistry
+from lib.palette.exporters.rgb_exporter import RGBExporter
+from lib.palette.exporters.gimp_exporter import GimpExporter
+from mamba import description, context, it, before
+from expects import expect, equal, be_a, have_length, contain, raise_error
+
+
+with description('ExporterRegistry') as self:
+
+    with before.each:
+        # Sauvegarder l'état et repartir propre
+        self._saved = dict(ExporterRegistry._exporters)
+        ExporterRegistry.reset()
+
+    with context('reset'):
+        with it('vide completement le registre'):
+            ExporterRegistry.register('rgb', RGBExporter)
+            ExporterRegistry.reset()
+            expect(ExporterRegistry.available_formats()).to(have_length(0))
+
+    with context('register et get_exporter_class'):
+        with it('enregistre et retrouve un exporter'):
+            ExporterRegistry.register('rgb', RGBExporter)
+            expect(ExporterRegistry.get_exporter_class('rgb')).to(equal(RGBExporter))
+
+        with it('normalise le nom en minuscules'):
+            ExporterRegistry.register('GIMP', GimpExporter)
+            expect(ExporterRegistry.get_exporter_class('gimp')).to(equal(GimpExporter))
+
+    with context('get_exporter_class avec format inconnu'):
+        with it('leve ValueError'):
+            expect(lambda: ExporterRegistry.get_exporter_class('unknown')).to(
+                raise_error(ValueError)
+            )
+
+    with context('available_formats'):
+        with it('retourne la liste des formats enregistres'):
+            ExporterRegistry.register('rgb', RGBExporter)
+            ExporterRegistry.register('gimp', GimpExporter)
+            formats = ExporterRegistry.available_formats()
+            expect(formats).to(contain('rgb'))
+            expect(formats).to(contain('gimp'))
+
+        with it('retourne une liste vide si rien enregistre'):
+            expect(ExporterRegistry.available_formats()).to(have_length(0))
+
+    # Restaurer l'état initial pour ne pas casser les autres specs
+    with after.each:
+        ExporterRegistry._exporters = self._saved

--- a/spec/parsers/adobe_aco_parser_spec.py
+++ b/spec/parsers/adobe_aco_parser_spec.py
@@ -2,11 +2,30 @@
 
 import sys
 import os
+import struct
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 
 from lib.parsers.adobe_aco_parser import AdobeAcoParser
 from mamba import description, context, it
-from expects import expect, equal, be_true, be_false, be_empty
+from expects import expect, equal, be_true, be_false, be_empty, have_length
+
+
+def _build_aco_header(num_colors):
+    """Construit le header ACO v1 : version 1 + nombre de couleurs"""
+    return struct.pack('>HH', 1, num_colors)
+
+
+def _build_rgb_entry(r, g, b):
+    """Construit un bloc couleur RGB ACO (color space 0, valeurs 0-65535)"""
+    w = round(r * 65535 / 255)
+    x = round(g * 65535 / 255)
+    y = round(b * 65535 / 255)
+    return struct.pack('>HHHHH', 0, w, x, y, 0)
+
+
+def _build_non_rgb_entry(color_space=1):
+    """Construit un bloc couleur non-RGB (ex: HSB = 1)"""
+    return struct.pack('>HHHHH', color_space, 0, 0, 0, 0)
 
 
 with description('AdobeAcoParser') as self:
@@ -36,8 +55,60 @@ with description('AdobeAcoParser') as self:
             expect(parser.can_parse(b'')).to(be_false)
 
     with context('parse'):
-        with it('retourne une liste vide (implementation basique)'):
+        with it('parse une couleur RGB'):
             parser = AdobeAcoParser()
-            content = bytes([0x00, 0x01, 0x00, 0x05])
+            content = _build_aco_header(1) + _build_rgb_entry(255, 0, 0)
             result = parser.parse(content)
+            expect(result).to(have_length(1))
+            expect(result[0].r).to(equal(255))
+            expect(result[0].g).to(equal(0))
+            expect(result[0].b).to(equal(0))
+
+        with it('parse plusieurs couleurs RGB'):
+            parser = AdobeAcoParser()
+            content = (_build_aco_header(3)
+                       + _build_rgb_entry(255, 0, 0)
+                       + _build_rgb_entry(0, 255, 0)
+                       + _build_rgb_entry(0, 0, 255))
+            result = parser.parse(content)
+            expect(result).to(have_length(3))
+            expect(result[0].r).to(equal(255))
+            expect(result[1].g).to(equal(255))
+            expect(result[2].b).to(equal(255))
+
+        with it('ignore les couleurs non-RGB'):
+            parser = AdobeAcoParser()
+            content = (_build_aco_header(3)
+                       + _build_rgb_entry(255, 0, 0)
+                       + _build_non_rgb_entry(1)    # HSB, ignoré
+                       + _build_rgb_entry(0, 0, 255))
+            result = parser.parse(content)
+            expect(result).to(have_length(2))
+            expect(result[0].r).to(equal(255))
+            expect(result[1].b).to(equal(255))
+
+        with it('retourne liste vide pour 0 couleurs'):
+            parser = AdobeAcoParser()
+            content = _build_aco_header(0)
+            result = parser.parse(content)
+            expect(result).to(be_empty)
+
+        with it('gere un fichier tronque en retournant les couleurs lisibles'):
+            parser = AdobeAcoParser()
+            # Annonce 3 couleurs mais n'en fournit qu'une complete
+            content = _build_aco_header(3) + _build_rgb_entry(128, 64, 32) + b'\x00\x00'
+            result = parser.parse(content)
+            expect(result).to(have_length(1))
+            expect(result[0].r).to(equal(128))
+            expect(result[0].g).to(equal(64))
+            expect(result[0].b).to(equal(32))
+
+        with it('retourne liste vide si content trop court pour le header'):
+            parser = AdobeAcoParser()
+            result = parser.parse(bytes([0x00, 0x01]))
+            expect(result).to(be_empty)
+
+        with it('retourne liste vide si content n est pas bytes'):
+            parser = AdobeAcoParser()
+            result = parser.parse("not binary")
             expect(result).to(be_empty)


### PR DESCRIPTION
## Summary

- **Parser Adobe ACO** : remplacement du stub par une implementation reelle avec `struct.unpack` (RGB, gestion fichiers tronques)
- **Coverage 94% → 96%** : nouvelles specs pour `exporter_registry`, `exporter_context`, wrapping teinte HSV
- **Documentation** : ajout des formats `css` et `amiga` dans `docs/nodes/palette_formatter.md`

### Details coverage

| Module | Avant | Apres |
|---|---|---|
| `exporter_registry.py` | 83% | 100% |
| `hsv_mixer.py` | 85% | 100% |
| `exporter_context.py` | 86% | 100% |
| `adobe_aco_parser.py` | stub | 100% |

## Test plan

- [x] `mamba spec/ --enable-coverage --format=documentation` — 218 specs vertes
- [x] Coverage globale 96%, aucun module testable sous 89%
- [x] Lefthook pre-commit passe